### PR TITLE
Removing styling files, and linking Bulma stylesheet to HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
     <title>Document</title>
   </head>
   <header>


### PR DESCRIPTION
For most basic and simple use of pre-made Bulba class properties, there is not need for a '.css' file. We simply will need to link Bulms'a css file to HTML and can use it instantly.